### PR TITLE
wake-up by just adding a card on the reader (PN5180 low power card detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ You can enable low power card detection with `PN5180_ENABLE_LPCD`. With low powe
 | ESP32 (GPIO)  | Hardware              | Pin    | Comment                                                           |
 | ------------- | --------------------- | ------ | ----------------------------------------------------------------- |
 | 3.3 V         | PN5180 RFID-reader    | 3.3V   | Connect directly to GPIO 17 for power-saving when uC is off       |
-| 5 / 3.3 V     |                       | 3.3V   | For low power card detection mode (LPCD) connect directly to 3.3V |
+| 3.3 V         |                       | 3.3V   | For low power card detection mode (LPCD) connect directly to 3.3V |
 | 5 / 3.3 V     | PN5180 RFID-reader    | 5V     | Don't forget to connect this pin the same way as 3.3V             |
 | GND           | PN5180 RFID-reader    | GND    |                                                                   |
 | 21            | PN5180 RFID-reader    | CS/SDA | Same as MFRC522. Don't share with SD!                             |

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3845,7 +3845,7 @@ void printWakeUpReason(){
 }
 
 // wake up from LPCD, check card is present. This works only for ISO-14443 compatible cards
-void checCardIsPresentLPCD() {
+void checkCardIsPresentLPCD() {
     static PN5180ISO14443 nfc14443(RFID_CS, RFID_BUSY, RFID_RST);
     nfc14443.begin();
     nfc14443.reset();
@@ -3886,7 +3886,7 @@ void setup() {
         esp_sleep_wakeup_cause_t wakeup_reason;
         wakeup_reason = esp_sleep_get_wakeup_cause();
         if (wakeup_reason == ESP_SLEEP_WAKEUP_EXT1) {
-            checCardIsPresentLPCD();
+            checkCardIsPresentLPCD();
         }
     #endif
    srand(esp_random());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,7 +228,7 @@ char *currentRfidTagId = NULL;
 unsigned long lastTimeActiveTimestamp = 0;              // Timestamp of last user-interaction
 unsigned long sleepTimerStartTimestamp = 0;             // Flag if sleep-timer is active
 bool gotoSleep = false;                                 // Flag for turning uC immediately into deepsleep
-bool sleeping = false;                                  // Flag for turning uC immediately into deepsleep
+bool sleeping = false;                                  // Flag for turning into deepsleep is in progress
 bool lockControls = false;                              // Flag if buttons and rotary encoder is locked
 bool bootComplete = false;
 // Rotary encoder-helper

--- a/src/settings-lolin32.h
+++ b/src/settings-lolin32.h
@@ -39,6 +39,8 @@
 #ifdef RFID_READER_TYPE_PN5180
     #define RFID_BUSY                   16          // PN5180 BUSY PIN
     #define RFID_RST                    22          // PN5180 RESET PIN
+    #define RFID_IRQ                    39          // PN5180 IRQ PIN (only needed for low power card detection)
+	#define BUTTON_PIN_BITMASK          0x8000000000// 2^RFID_IRQ in hex
 #endif
 // I2S (DAC)
 #define I2S_DOUT                        25          // Digital out (I2S)

--- a/src/settings-lolin_d32.h
+++ b/src/settings-lolin_d32.h
@@ -39,6 +39,8 @@
 #ifdef RFID_READER_TYPE_PN5180
     #define RFID_BUSY                   16          // PN5180 BUSY PIN
     #define RFID_RST                    22          // PN5180 RESET PIN
+    #define RFID_IRQ                    39          // PN5180 IRQ PIN (only needed for low power card detection)
+	#define BUTTON_PIN_BITMASK          0x8000000000// 2^RFID_IRQ in hex
 #endif
 // I2S (DAC)
 #define I2S_DOUT                        25          // Digital out (I2S)

--- a/src/settings-lolin_d32_pro.h
+++ b/src/settings-lolin_d32_pro.h
@@ -34,6 +34,8 @@
 #ifdef RFID_READER_TYPE_PN5180
     #define RFID_BUSY                   16          // PN5180 BUSY PIN
     #define RFID_RST                    22          // PN5180 RESET PIN
+    #define RFID_IRQ                    39          // PN5180 IRQ PIN (only needed for low power card detection)
+	#define BUTTON_PIN_BITMASK          0x8000000000// 2^RFID_IRQ in hex
 #endif
 // I2S (DAC)
 #define I2S_DOUT                        25          // Digital out (I2S)

--- a/src/settings.h
+++ b/src/settings.h
@@ -38,7 +38,8 @@
 //################## select RFID reader ##############################
 #define RFID_READER_TYPE_MFRC522_SPI        // use MFRC522 via SPI
 //#define RFID_READER_TYPE_MFRC522_I2C        // use MFRC522 via I2C
-//#define RFID_READER_TYPE_PN5180
+//#define RFID_READER_TYPE_PN5180			  // use PN5180
+//#define PN5180_ENABLE_LPCD                    // enable PN5180 low power card detection: wake up on card detection
 
 
 //#################### Various settings ##############################


### PR DESCRIPTION
This pull request feature includes:
Put the card on the reader, board wakes up and just plays music. No button to press to get out of sleep..

Details:
PN5180 has a low power card detection mode (LPCD):
This mode activates a low power RF-field and can detect changes in the field. If a card (or metal) changes the RF-field the reader switch the IRQ pin to high. If this pin is configured as ESP-32 wake-up pin the board wakes up. power measurements show additional 300uA in deep sleep mode.

To enable this mode you have to define the `RFID_IRQ` pin (input to ESP-32, e.g. 39) and the define `PN5180_ENABLE_LPCD`.
The firmware of PN5180 must be up to date. Most china boards comes with V3.5, this version is unusable. You have to flash the reader to latest version 4.1. This can be done with this [project](https://github.com/abidxraihan/PN5180_Updater_ESP32) using a ESP-32.

ESP_SLEEP_WAKEUP_EXT1 is used to detect the wake-up reason. On wake-up the PN5180 is initialized and reading the card id. if no id found (false alarm, only metal changed the RF field) the ESP-32 is going to sleep again.


https://user-images.githubusercontent.com/11274319/104109985-99fcf100-52d3-11eb-904b-f5dd95ccb24d.mov


Greetings
tueddy

